### PR TITLE
Add RomanNumerals extension and tests

### DIFF
--- a/roman-numerals/RomanNumerals.cs
+++ b/roman-numerals/RomanNumerals.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 public static class RomanNumeralExtension

--- a/roman-numerals/RomanNumerals.cs
+++ b/roman-numerals/RomanNumerals.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public static class RomanNumeralExtension
+{
+    private static readonly Dictionary<int, string> ArabicToRoman = new()
+    {
+        { 1000, "M" },
+        { 900, "CM" },
+        { 500, "D" },
+        { 400, "CD" },
+        { 100, "C" },
+        { 90, "XC" },
+        { 50, "L" },
+        { 40, "XL" },
+        { 10, "X" },
+        { 9, "IX" },
+        { 5, "V" },
+        { 4, "IV" },
+        { 1, "I" }
+    };
+
+    public static string ToRoman(this int value)
+    {
+        StringBuilder roman = new();
+        foreach (var (threshold, numeral) in ArabicToRoman)
+        {
+            while (threshold <= value)
+            {
+                roman.Append(numeral);
+                value -= threshold;
+            }
+        }
+
+        return roman.ToString();
+    }
+}

--- a/roman-numerals/RomanNumerals.csproj
+++ b/roman-numerals/RomanNumerals.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/roman-numerals/RomanNumeralsTests.cs
+++ b/roman-numerals/RomanNumeralsTests.cs
@@ -1,0 +1,160 @@
+using Xunit;
+
+public class RomanNumeralsTests
+{
+    [Fact]
+    public void Number_1_is_i()
+    {
+        Assert.Equal("I", 1.ToRoman());
+    }
+
+    [Fact]
+    public void Number_2_is_ii()
+    {
+        Assert.Equal("II", 2.ToRoman());
+    }
+
+    [Fact]
+    public void Number_3_is_iii()
+    {
+        Assert.Equal("III", 3.ToRoman());
+    }
+
+    [Fact]
+    public void Number_4_is_iv()
+    {
+        Assert.Equal("IV", 4.ToRoman());
+    }
+
+    [Fact]
+    public void Number_5_is_v()
+    {
+        Assert.Equal("V", 5.ToRoman());
+    }
+
+    [Fact]
+    public void Number_6_is_vi()
+    {
+        Assert.Equal("VI", 6.ToRoman());
+    }
+
+    [Fact]
+    public void Number_9_is_ix()
+    {
+        Assert.Equal("IX", 9.ToRoman());
+    }
+
+    [Fact]
+    public void Number_27_is_xxvii()
+    {
+        Assert.Equal("XXVII", 27.ToRoman());
+    }
+
+    [Fact]
+    public void Number_48_is_xlviii()
+    {
+        Assert.Equal("XLVIII", 48.ToRoman());
+    }
+
+    [Fact]
+    public void Number_49_is_xlix()
+    {
+        Assert.Equal("XLIX", 49.ToRoman());
+    }
+
+    [Fact]
+    public void Number_59_is_lix()
+    {
+        Assert.Equal("LIX", 59.ToRoman());
+    }
+
+    [Fact]
+    public void Number_93_is_xciii()
+    {
+        Assert.Equal("XCIII", 93.ToRoman());
+    }
+
+    [Fact]
+    public void Number_141_is_cxli()
+    {
+        Assert.Equal("CXLI", 141.ToRoman());
+    }
+
+    [Fact]
+    public void Number_163_is_clxiii()
+    {
+        Assert.Equal("CLXIII", 163.ToRoman());
+    }
+
+    [Fact]
+    public void Number_402_is_cdii()
+    {
+        Assert.Equal("CDII", 402.ToRoman());
+    }
+
+    [Fact]
+    public void Number_575_is_dlxxv()
+    {
+        Assert.Equal("DLXXV", 575.ToRoman());
+    }
+
+    [Fact]
+    public void Number_911_is_cmxi()
+    {
+        Assert.Equal("CMXI", 911.ToRoman());
+    }
+
+    [Fact]
+    public void Number_1024_is_mxxiv()
+    {
+        Assert.Equal("MXXIV", 1024.ToRoman());
+    }
+
+    [Fact]
+    public void Number_3000_is_mmm()
+    {
+        Assert.Equal("MMM", 3000.ToRoman());
+    }
+
+    [Fact]
+    public void Number_16_is_xvi()
+    {
+        Assert.Equal("XVI", 16.ToRoman());
+    }
+
+    [Fact]
+    public void Number_66_is_lxvi()
+    {
+        Assert.Equal("LXVI", 66.ToRoman());
+    }
+
+    [Fact]
+    public void Number_166_is_clxvi()
+    {
+        Assert.Equal("CLXVI", 166.ToRoman());
+    }
+
+    [Fact]
+    public void Number_666_is_dclxvi()
+    {
+        Assert.Equal("DCLXVI", 666.ToRoman());
+    }
+
+    [Fact]
+    public void Number_1666_is_mdclxvi()
+    {
+        Assert.Equal("MDCLXVI", 1666.ToRoman());
+    }
+
+    [Fact]
+    public void Number_3001_is_mmmi()
+    {
+        Assert.Equal("MMMI", 3001.ToRoman());
+    }
+
+    [Fact]
+    public void Number_3999_is_mmmcmxcix()
+    {
+        Assert.Equal("MMMCMXCIX", 3999.ToRoman());
+    }
+}


### PR DESCRIPTION
Added a new 'RomanNumerals' extension method in 'RomanNumerals.cs' to convert an integer into Roman numerals. An accompanying test suite, 'RomanNumeralsTests.cs', was also created with various test cases to verify the correctness of the conversion. Additionally, updated the 'RomanNumerals.csproj' to include necessary packages and set the .NET target framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to convert integers to Roman numeral strings.
- **Tests**
	- Added tests for the new Roman numeral conversion functionality.
- **Chores**
	- Set up a .NET project configuration targeting `net8.0` and included necessary packages for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->