### PR TITLE
Add 'InternationalCallingConnoisseur' project with related files and …

### DIFF
--- a/Exercism.sln
+++ b/Exercism.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BirdWatcher", "bird-watcher
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TracksOnTracksOnTracks", "tracks-on-tracks-on-tracks\TracksOnTracksOnTracks.csproj", "{377F04A5-7D55-45BC-A9D4-3C4A140D532A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InternationalCallingConnoisseur", "international-calling-connoisseur\InternationalCallingConnoisseur.csproj", "{6B003381-0749-460B-99B7-47DD28B0B69B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +101,10 @@ Global
 		{377F04A5-7D55-45BC-A9D4-3C4A140D532A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{377F04A5-7D55-45BC-A9D4-3C4A140D532A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{377F04A5-7D55-45BC-A9D4-3C4A140D532A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B003381-0749-460B-99B7-47DD28B0B69B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B003381-0749-460B-99B7-47DD28B0B69B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B003381-0749-460B-99B7-47DD28B0B69B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B003381-0749-460B-99B7-47DD28B0B69B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/international-calling-connoisseur/InternationalCallingConnoisseur.cs
+++ b/international-calling-connoisseur/InternationalCallingConnoisseur.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class DialingCodes
+{
+    public static Dictionary<int, string> GetEmptyDictionary() => new();
+
+    public static Dictionary<int, string> GetExistingDictionary() => new()
+    {
+        { 1, "United States of America" }, { 55, "Brazil" }, { 91, "India" }
+    };
+
+    public static Dictionary<int, string> AddCountryToEmptyDictionary(int countryCode, string countryName) => new()
+    {
+        { countryCode, countryName }
+    };
+
+    public static Dictionary<int, string> AddCountryToExistingDictionary(
+        Dictionary<int, string> existingDictionary, int countryCode, string countryName)
+    {
+        existingDictionary[countryCode] = countryName;
+        return existingDictionary;
+    }
+
+    public static string GetCountryNameFromDictionary(
+        Dictionary<int, string> existingDictionary, int countryCode)
+        => existingDictionary.GetValueOrDefault(countryCode, string.Empty);
+
+    public static bool CheckCodeExists(Dictionary<int, string> existingDictionary, int countryCode)
+        => existingDictionary.ContainsKey(countryCode);
+
+    public static Dictionary<int, string> UpdateDictionary(
+        Dictionary<int, string> existingDictionary, int countryCode, string countryName)
+    {
+        if (CheckCodeExists(existingDictionary, countryCode))
+            existingDictionary[countryCode] = countryName;
+        return existingDictionary;
+    }
+
+    public static Dictionary<int, string> RemoveCountryFromDictionary(
+        Dictionary<int, string> existingDictionary, int countryCode)
+    {
+        existingDictionary.Remove(countryCode);
+        return existingDictionary;
+    }
+
+    public static string FindLongestCountryName(Dictionary<int, string> existingDictionary)
+        => existingDictionary.Count == 0 
+            ? string.Empty 
+            : existingDictionary.MaxBy(x => x.Value.Length).Value;
+}

--- a/international-calling-connoisseur/InternationalCallingConnoisseur.csproj
+++ b/international-calling-connoisseur/InternationalCallingConnoisseur.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
+++ b/international-calling-connoisseur/InternationalCallingConnoisseurTests.cs
@@ -1,0 +1,296 @@
+using Xunit;
+using Exercism.Tests;
+
+public class InternationalCallingConnoisseurTests
+{
+    [Fact]
+    [Task(1)]
+    public void Empty_dictionary_is_empty()
+    {
+        var emptyDict = DialingCodes.GetEmptyDictionary();
+        Assert.Empty(emptyDict);
+    }
+
+    [Fact]
+    [Task(2)]
+    public void Existing_dictionary_count_is_3()
+    {
+        var prePopulated = DialingCodes.GetExistingDictionary();
+        Assert.Equal(3, prePopulated.Count);
+    }
+
+    [Fact]
+    [Task(2)]
+    public void Existing_dictionary_1_is_United_States_of_America()
+    {
+        var prePopulated = DialingCodes.GetExistingDictionary();
+        Assert.Equal("United States of America", prePopulated[1]);
+    }
+
+    [Fact]
+    [Task(2)]
+    public void Existing_dictionary_55_is_Brazil()
+    {
+        var prePopulated = DialingCodes.GetExistingDictionary();
+        Assert.Equal("Brazil", prePopulated[55]);
+    }
+
+    [Fact]
+    [Task(2)]
+    public void Existing_dictionary_91_is_India()
+    {
+        var prePopulated = DialingCodes.GetExistingDictionary();
+        Assert.Equal("India", prePopulated[91]);
+    }
+
+    [Fact]
+    [Task(3)]
+    public void Add_country_to_empty_dictionary_single()
+    {
+        var countryCodes = DialingCodes.AddCountryToEmptyDictionary(44, "United Kingdom");
+        Assert.Single(countryCodes);
+    }
+
+    [Fact]
+    [Task(3)]
+    public void Add_country_to_empty_dictionary_44_is_United_Kingdom()
+    {
+        var countryCodes = DialingCodes.AddCountryToEmptyDictionary(44, "United Kingdom");
+        Assert.Equal("United Kingdom", countryCodes[44]);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Add_country_to_existing_dictionary_count_is_1()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 44, "United Kingdom");
+        Assert.Equal(4, countryCodes.Count);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Add_country_to_existing_dictionary_1_is_United_States_of_America()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 44, "United Kingdom");
+        Assert.Equal("United States of America", countryCodes[1]);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Add_country_to_existing_dictionary_44_is_United_Kingdom()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 44, "United Kingdom");
+        Assert.Equal("United Kingdom", countryCodes[44]);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Add_country_to_existing_dictionary_55_is_Brazil()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 44, "United Kingdom");
+        Assert.Equal("Brazil", countryCodes[55]);
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Add_country_to_existing_dictionary_91_is_India()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 44, "United Kingdom");
+        Assert.Equal("India", countryCodes[91]);
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Get_country_name_from_dictionary()
+    {
+        var countryName = DialingCodes.GetCountryNameFromDictionary(
+            DialingCodes.GetExistingDictionary(), 55);
+        Assert.Equal("Brazil", countryName);
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Get_country_name_for_non_existent_country()
+    {
+        var countryName = DialingCodes.GetCountryNameFromDictionary(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.Equal(string.Empty, countryName);
+    }
+
+    [Fact]
+    [Task(6)]
+    public void Check_country_exists()
+    {
+        var exists = DialingCodes.CheckCodeExists(
+            DialingCodes.GetExistingDictionary(), 55);
+        Assert.True(exists);
+    }
+
+    [Fact]
+    [Task(6)]
+    public void Check_country_exists_for_non_existent_country()
+    {
+        var exists = DialingCodes.CheckCodeExists(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.False(exists);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_count_is_3()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 1, "les États-Unis");
+        Assert.Equal(3, countryCodes.Count);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_1_is_les_Etats_Unis()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 1, "les États-Unis");
+        Assert.Equal("les États-Unis", countryCodes[1]);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_55_is_Brazil()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 1, "les États-Unis");
+        Assert.Equal("Brazil", countryCodes[55]);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_91_is_India()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 1, "les États-Unis");
+        Assert.Equal("India", countryCodes[91]);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_for_non_existent_country_count_is_3()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 999, "Newlands");
+        Assert.Equal(3, countryCodes.Count);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_for_non_existent_country_1_is_United_States_of_America()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 999, "Newlands");
+        Assert.Equal("United States of America", countryCodes[1]);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_for_non_existent_country_55_is_Brazil()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 999, "Newlands");
+        Assert.Equal("Brazil", countryCodes[55]);
+    }
+
+    [Fact]
+    [Task(7)]
+    public void Update_country_name_in_dictionary_for_non_existent_country_91_is_India()
+    {
+        var countryCodes = DialingCodes.UpdateDictionary(
+            DialingCodes.GetExistingDictionary(), 999, "Newlands");
+        Assert.Equal("India", countryCodes[91]);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_count_is_2()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 91);
+        Assert.Equal(2, countryCodes.Count);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_1_is_United_States_of_America()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 91);
+        Assert.Equal("United States of America", countryCodes[1]);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_55_is_Brazil()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 91);
+        Assert.Equal("Brazil", countryCodes[55]);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_for_non_existent_country_count_is_3()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.Equal(3, countryCodes.Count);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_for_non_existent_country_1_is_United_States_of_America()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.Equal("United States of America", countryCodes[1]);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_for_non_existent_country_55_is_Brazil()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.Equal("Brazil", countryCodes[55]);
+    }
+
+    [Fact]
+    [Task(8)]
+    public void Remove_country_from_dictionary_for_non_existent_country_91_is_India()
+    {
+        var countryCodes = DialingCodes.RemoveCountryFromDictionary(
+            DialingCodes.GetExistingDictionary(), 999);
+        Assert.Equal("India", countryCodes[91]);
+    }
+
+    [Fact]
+    [Task(9)]
+    public void Longest_country_name()
+    {
+        var countryCodes = DialingCodes.AddCountryToExistingDictionary(
+            DialingCodes.GetExistingDictionary(), 263, "Zimbabwe");
+        var longestCountryName = DialingCodes.FindLongestCountryName(countryCodes);
+        Assert.Equal("United States of America", longestCountryName);
+    }
+
+    [Fact]
+    [Task(9)]
+    public void Longest_country_name_for_empty_dictionary()
+    {
+        var longestCountryName = DialingCodes.FindLongestCountryName(
+            DialingCodes.GetEmptyDictionary());
+        Assert.Equal(string.Empty, longestCountryName);
+    }
+}

--- a/international-calling-connoisseur/README.md
+++ b/international-calling-connoisseur/README.md
@@ -1,0 +1,184 @@
+# International Calling Connoisseur
+
+Welcome to International Calling Connoisseur on Exercism's C# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+If you get stuck on the exercise, check out `HINTS.md`, but try and solve it without using those first :)
+
+## Introduction
+
+## Dictionaries
+
+A dictionary is a collection of elements where each element comprises a key and value such that if a key is passed to a method of the dictionary its associated value is returned. It has the same role as maps or associative arrays do in other languages.
+
+A dictionary can be created as follows:
+
+```csharp
+new Dictionary<int, string>();
+// Empty dictionary
+```
+
+Or
+
+```csharp
+new Dictionary<int, string>
+{
+    [1] = "One",
+    [2] = "Two"
+};
+
+// Or
+
+new Dictionary<int, string>
+{
+    {1, "One"},
+    {2, "Two"}
+};
+// 1 => "One", 2 => "Two"
+```
+
+Note that the key and value types are part of the definition of the dictionary.
+
+Once constructed, entries can be added or removed from a dictionary using its built-in methods `Add` and `Remove`.
+
+Retrieving or updating values in a dictionary is done by indexing into the dictionary using a key:
+
+```csharp
+var numbers = new Dictionary<int, string>
+{
+   {1, "One"},
+   {2, "Two"}
+};
+
+// Set the value of the element with key 2 to "Deux"
+numbers[2] = "Deux";
+
+// Get the value of the element with key 2
+numbers[2];
+// => "Deux"
+```
+
+You can test if a value exists in the dictionary with:
+
+```csharp
+var dict = new Dictionary<string, string>{/*...*/};
+dict.ContainsKey("some key that exists");
+// => true
+```
+
+Enumerating over a dictionary will enumerate over its key/value pairs. Dictionaries also have properties that allow enumerating over its keys or values.
+
+[indexer-properties]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/indexers/
+
+## Instructions
+
+In this exercise you'll be writing code to keep track of international dialling codes via an international dialing code dictionary.
+
+The dictionary uses an integer for its keys (the dialing code) and a string (country name) for its values.
+
+You have 9 tasks which involve the `DialingCodes` static class.
+
+## 1. Create a new dictionary
+
+Implement the (static) method `DialingCodes.GetEmptyDictionary()` that returns an empty dictionary.
+
+```csharp
+DialingCodes.GetEmptyDictionary();
+// => empty dictionary
+```
+
+## 2. Create a pre-populated dictionary
+
+There exists a pre-populated dictionary which contains the following 3 dialing codes: "United States of America" which has a code of 1, "Brazil" which has a code of 55 and "India" which has a code of 91. Implement the (static) `DialingCodes.GetExistingDictionary()` method to return the pre-populated dictionary:
+
+```csharp
+DialingCodes.GetExistingDictionary();
+// => 1 => "United States of America", 55 => "Brazil", 91 => "India"
+```
+
+## 3. Add a country to an empty dictionary
+
+Implement the (static) method `DialingCodes.AddCountryToEmptyDictionary()` that creates a dictionary and adds a dialing code and associated country name to it.
+
+```csharp
+DialingCodes.AddCountryToEmptyDictionary(44, "United Kingdom");
+// => 44 => "United Kingdom"
+```
+
+## 4. Add a country to an existing dictionary
+
+Implement the (static) method `DialingCodes.AddCountryToExistingDictionary()` that adds a dialing code and associated country name to a non-empty dictionary.
+
+```csharp
+DialingCodes.AddCountryToExistingDictionary(DialingCodes.GetExistingDictionary(),
+  44, "United Kingdom");
+// => 1 => "United States of America", 44 => "United Kingdom", 55 => "Brazil", 91 => "India"
+```
+
+## 5. Get the country name matching a dialing code
+
+Implement the (static) method `DialingCodes.GetCountryNameFromDictionary()` that takes a dialing code and returns the corresponding country name. If the dialing code is not contained in the dictionary then an empty string is returned.
+
+```csharp
+DialingCodes.GetCountryNameFromDictionary(
+  DialingCodes.GetExistingDictionary(), 55);
+// => "Brazil"
+
+DialingCodes.GetCountryNameFromDictionary(
+  DialingCodes.GetExistingDictionary(), 999);
+// => string.Empty
+```
+
+## 6. Check that a country exists in the dictionary
+
+Implement the (static) method `DialingCodes.CheckCodeExists()` to check whether a dialing code exists in the dictionary.
+
+```csharp
+DialingCodes.CheckCodeExists(DialingCodes.GetExistingDictionary(), 55);
+// => true
+```
+
+## 7. Update a country name
+
+Implement the (static) method `DialingCodes.UpdateDictionary()` which takes a dialing code and replaces the corresponding country name in the dictionary with the country name passed as a parameter. If the dialing code does not exist in the dictionary then the dictionary remains unchanged.
+
+```csharp
+DialingCodes.UpdateDictionary(
+  DialingCodes.GetExistingDictionary(), 1, "Les États-Unis");
+// => 1 => "Les États-Unis", 55 => "Brazil", 91 => "India"
+
+DialingCodes.UpdateDictionary(
+  DialingCodes.GetExistingDictionary(), 999, "Newlands");
+// 1 => "United States of America", 55 => "Brazil", 91 => "India"
+```
+
+## 8. Remove a country from the dictionary
+
+Implement the (static) method `DialingCodes.RemoveCountryFromDictionary()` that takes a dialing code and will remove the corresponding record, dialing code + country name, from the dictionary.
+
+```csharp
+DialingCodes.RemoveCountryFromDictionary(
+  DialingCodes.GetExistingDictionary(), 91);
+// => 1 => "United States of America", 55 => "Brazil"
+```
+
+## 9. Find the country with the longest name
+
+Implement the (static) method `DialingCodes.FindLongestCountryName()` which will return the name of the country with the longest name stored in the dictionary.
+
+```csharp
+DialingCodes.FindLongestCountryName(
+  DialingCodes.GetExistingDictionary());
+// => "United States of America"
+```
+
+## Source
+
+### Created by
+
+- @mikedamay
+
+### Contributed to by
+
+- @ErikSchierboom
+- @valentin-p
+- @yzAlvin


### PR DESCRIPTION
…tests

This commit includes the new 'InternationalCallingConnoisseur' project. The project teaches about interacting with C# Dictionaries, with tasks to create, update, and search dictionaries. The commit also adds the tests and readme file for the tasks, and integrates it into the existing solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the "International Calling Connoisseur" project, focusing on managing international dialing codes.
	- Added functionality to create, update, retrieve, and remove country dialing codes, including finding the longest country name.
- **Documentation**
	- Provided a comprehensive guide on using dictionaries in C# through the "International Calling Connoisseur" exercise.
- **Tests**
	- Implemented test cases for validating the functionality of managing international dialing codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->