### PR TITLE
Add 'WizardsAndWarriors' game and related components

### DIFF
--- a/Exercism.sln
+++ b/Exercism.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HyperOptimizedTelemetry", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookStore", "book-store\BookStore.csproj", "{A0EC4B77-B9AD-4816-87A4-52D80500D267}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WizardsAndWarriors", "wizards-and-warriors\WizardsAndWarriors.csproj", "{B14990A5-BB58-4992-AA95-C30E8E925377}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,10 @@ Global
 		{A0EC4B77-B9AD-4816-87A4-52D80500D267}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0EC4B77-B9AD-4816-87A4-52D80500D267}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0EC4B77-B9AD-4816-87A4-52D80500D267}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B14990A5-BB58-4992-AA95-C30E8E925377}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B14990A5-BB58-4992-AA95-C30E8E925377}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B14990A5-BB58-4992-AA95-C30E8E925377}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B14990A5-BB58-4992-AA95-C30E8E925377}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wizards-and-warriors/README.md
+++ b/wizards-and-warriors/README.md
@@ -1,0 +1,206 @@
+# Wizards and Warriors
+
+Welcome to Wizards and Warriors on Exercism's C# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+If you get stuck on the exercise, check out `HINTS.md`, but try and solve it without using those first :)
+
+## Introduction
+
+## Inheritance
+
+In C#, a _class_ hierarchy can be defined using _inheritance_, which allows a derived class (`Car`) to inherit the behavior and data of its parent class (`Vehicle`). If no parent is specified, the class inherits from the `object` class.
+
+Parent classes can provide functionality to derived classes in three ways:
+
+- Define a regular method.
+- Define a `virtual` method, which is like a regular method but one that derived classes _can_ change.
+- Define an `abstract` method, which is a method without an implementation that derived classes _must_ implement. A class with `abstract` methods must be marked as `abstract` too. Abstract classes cannot be instantiated.
+
+The `protected` access modifier allows a parent class member to be accessed in a derived class, but blocks access from other classes.
+
+Derived classes can access parent class members through the `base` keyword.
+
+```csharp
+// Inherits from the 'object' class
+abstract class Vehicle
+{
+    // Can be overridden
+    public virtual void Drive()
+    {
+    }
+
+    // Must be overridden
+    protected abstract int Speed();
+}
+
+class Car : Vehicle
+{
+    public override void Drive()
+    {
+        // Override virtual method
+
+        // Call parent implementation
+        base.Drive();
+    }
+
+    protected override int Speed()
+    {
+        // Implement abstract method
+    }
+}
+```
+
+The constructor of a derived class will automatically call its parent's constructor _before_ executing its own constructor's logic. Arguments can be passed to a parent class' constructor using the `base` keyword:
+
+```csharp
+abstract class Vehicle
+{
+    protected Vehicle(int wheels)
+    {
+        Console.WriteLine("Called first");
+    }
+}
+
+class Car : Vehicle
+{
+    public Car() : base(4)
+    {
+        Console.WriteLine("Called second");
+    }
+}
+```
+
+Where more than one class is derived from a base class the two (or more) classes will often implement different versions of a base class method. This is a very important principle called polymorphism. For instance in a variation on the above example we show how code using `Vehicle` can change its behavior depending on what type of vehicle has been instantiated.
+
+```csharp
+abstract class Vehicle
+{
+   public abstract string GetDescription();
+}
+
+class Car : Vehicle
+{
+   public Car()
+   {
+   }
+
+   public override string GetDescription()
+   {
+      return "Runabout";
+   }
+}
+
+class Rig : Vehicle
+{
+   public Rig()
+   {
+   }
+
+   public override string GetDescription()
+   {
+      return "Big Rig";
+   }
+}
+
+Vehicle v1 = new Car();
+Vehicle v2 = new Rig();
+
+v1.GetDescription();
+// => Runabout
+v2.GetDescription();
+// => Big Rig
+```
+
+## Instructions
+
+In this exercise you're playing a role-playing game named "Wizard and Warriors," which allows you to play as either a Wizard or a Warrior.
+
+There are different rules for Warriors and Wizards to determine how much damage points they deal.
+
+For a Warrior, these are the rules:
+
+- Deal 6 points of damage if the character they are attacking is not vulnerable
+- Deal 10 points of damage if the character they are attacking is vulnerable
+
+For a Wizard, these are the rules:
+
+- Deal 12 points of damage if the Wizard prepared a spell in advance
+- Deal 3 points of damage if the Wizard did not prepare a spell in advance
+
+In general, characters are never vulnerable. However, Wizards _are_ vulnerable if they haven't prepared a spell.
+
+You have six tasks that work with Warriors and Wizard characters.
+
+## 1. Describe a character
+
+Override the `ToString()` method on the `Character` class to return a description of the character, formatted as `"Character is a <CHARACTER_TYPE>"`.
+
+```csharp
+var warrior = new Warrior();
+warrior.ToString();
+// => "Character is a Warrior"
+```
+
+## 2. Make characters not vulnerable by default
+
+Ensure that the `Character.Vulnerable()` method always returns `false`.
+
+```csharp
+var warrior = new Warrior();
+warrior.Vulnerable();
+// => false
+```
+
+## 3. Allow Wizards to prepare a spell
+
+Implement the `Wizard.PrepareSpell()` method to allow a Wizard to prepare a spell in advance.
+
+```csharp
+var wizard = new Wizard();
+wizard.PrepareSpell();
+```
+
+## 4. Make Wizards vulnerable when not having prepared a spell
+
+Ensure that the `Vulnerable()` method returns `true` if the wizard did not prepare a spell; otherwise, return `false`.
+
+```csharp
+var wizard = new Wizard();
+wizard.Vulnerable();
+// => true
+```
+
+## 5. Calculate the damage points for a Wizard
+
+Implement the `Wizard.DamagePoints()` method to return the damage points dealt: 12 damage points when a spell has been prepared, 3 damage points when not.
+
+```csharp
+var wizard = new Wizard();
+var warrior = new Warrior();
+
+wizard.PrepareSpell();
+wizard.DamagePoints(warrior);
+// => 12
+```
+
+## 6. Calculate the damage points for a Warrior
+
+Implement the `Warrior.DamagePoints()` method to return the damage points dealt: 10 damage points when the target is vulnerable, 6 damage points when not.
+
+```csharp
+var warrior = new Warrior();
+var wizard = new Wizard();
+
+warrior.DamagePoints(wizard);
+// => 10
+```
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @yzAlvin

--- a/wizards-and-warriors/WizardsAndWarriors.cs
+++ b/wizards-and-warriors/WizardsAndWarriors.cs
@@ -1,0 +1,19 @@
+internal abstract class Character
+{
+    public abstract int DamagePoints(Character target);
+    public virtual bool Vulnerable() => false;
+    public override string ToString() => $"Character is a {GetType().Name}";
+}
+
+internal class Warrior : Character
+{
+    public override int DamagePoints(Character target) => target.Vulnerable() ? 10 : 6;
+}
+
+internal class Wizard : Character
+{
+    private bool _prepared;
+    public override bool Vulnerable() => !_prepared;
+    public override int DamagePoints(Character target) => _prepared ? 12 : 3;
+    public void PrepareSpell() => _prepared = true;
+}

--- a/wizards-and-warriors/WizardsAndWarriors.csproj
+++ b/wizards-and-warriors/WizardsAndWarriors.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/wizards-and-warriors/WizardsAndWarriorsTests.cs
+++ b/wizards-and-warriors/WizardsAndWarriorsTests.cs
@@ -1,0 +1,97 @@
+using Xunit;
+using Exercism.Tests;
+
+public class WizardsAndWarriorsTests
+{
+    [Fact]
+    [Task(1)]
+    public void Describe_wizard()
+    {
+        var wizard = new Wizard();
+        Assert.Equal("Character is a Wizard", wizard.ToString());
+    }
+
+    [Fact]
+    [Task(1)]
+    public void Describe_warrior()
+    {
+        var warrior = new Warrior();
+        Assert.Equal("Character is a Warrior", warrior.ToString());
+    }
+
+    [Fact]
+    [Task(2)]
+    public void Warrior_is_not_vulnerable()
+    {
+        var warrior = new Warrior();
+        Assert.False(warrior.Vulnerable());
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Wizard_is_vulnerable()
+    {
+        var wizard = new Wizard();
+        Assert.True(wizard.Vulnerable());
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Wizard_with_prepared_spell_is_not_vulnerable()
+    {
+        var wizard = new Wizard();
+        wizard.PrepareSpell();
+        Assert.False(wizard.Vulnerable());
+    }
+
+    [Fact]
+    [Task(4)]
+    public void Wizard_with_no_prepared_spell_is_vulnerable()
+    {
+        var wizard = new Wizard();
+        Assert.True(wizard.Vulnerable());
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Attack_points_for_wizard_with_prepared_spell()
+    {
+        var wizard = new Wizard();
+        var warrior = new Warrior();
+
+        wizard.PrepareSpell();
+
+        Assert.Equal(12, wizard.DamagePoints(warrior));
+    }
+
+    [Fact]
+    [Task(5)]
+    public void Attack_points_for_wizard_with_no_prepared_spell()
+    {
+        var wizard = new Wizard();
+        var otherWizard = new Wizard();
+
+        Assert.Equal(3, wizard.DamagePoints(otherWizard));
+    }
+
+    [Fact]
+    [Task(6)]
+    public void Attack_points_for_warrior_with_vulnerable_target()
+    {
+        var warrior = new Warrior();
+        var wizard = new Wizard();
+
+        Assert.Equal(10, warrior.DamagePoints(wizard));
+    }
+
+    [Fact]
+    [Task(6)]
+    public void Attack_points_for_warrior_with_non_vulnerable_target()
+    {
+        var warrior = new Warrior();
+        var wizard = new Wizard();
+        wizard.PrepareSpell();
+
+        Assert.Equal(6, warrior.DamagePoints(wizard));
+    }
+}


### PR DESCRIPTION
This commit includes the addition of the 'WizardsAndWarriors' game, which allows you to play as either a Wizard or a Warrior. This includes the introduction of a new csproj file, C# code with classes and methods defining game characters and their behaviors, unit tests to ensure gameplay functionality and a README explaining the game concepts. Additionally, the WizardsAndWarriors project has also been added to the primary solution file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the "Wizards and Warriors" exercise to the C# Track, focusing on inheritance.
	- Added an abstract `Character` class with specific implementations for `Warrior` and `Wizard` roles.
	- Provided a project configuration for a .NET project targeting the `net8.0` framework.
	- Included test cases for validating the characteristics and interactions of `Wizard` and `Warrior` classes.

- **Documentation**
	- Added a `README.md` file explaining the exercise scenario, objectives, and inheritance in C#.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->