### PR TITLE
Add 'Change' project, coin change functionality, and relevant tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/coderabbit-overrides.v2.json
+language: "en-US"
+early_access: true
+reviews:
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+  path_filters:
+    - '!**/*.md'
+    - '!**/*.xml'
+    - '!**/*.csproj'
+    - '!**/*Tests.cs'
+chat:
+  auto_reply: true

--- a/Exercism.sln
+++ b/Exercism.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FootballMatchReports", "foo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalculatorConundrum", "calculator-conundrum\CalculatorConundrum.csproj", "{4F54886F-3873-4720-9962-0F63B2359303}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Change", "change\Change.csproj", "{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +149,10 @@ Global
 		{4F54886F-3873-4720-9962-0F63B2359303}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F54886F-3873-4720-9962-0F63B2359303}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F54886F-3873-4720-9962-0F63B2359303}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/change/Change.cs
+++ b/change/Change.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+public static class Change
+{
+    public static int[] FindFewestCoins(int[] coins, int target)
+    {
+        if (target == 0) return Array.Empty<int>(); // No coins for 0 change
+        if (target < 0) throw new ArgumentException("Negative change not allowed");
+
+        int[] dp = new int[target + 1];
+        int[] chosenCoin = new int[target + 1];
+
+        for (int i = 1; i <= target; i++)
+        {
+            dp[i] = int.MaxValue;
+            foreach (int coin in coins)
+            {
+                if (coin > i) continue;
+                if (dp[i - coin] + 1 < dp[i])
+                {
+                    dp[i] = dp[i - coin] + 1;
+                    chosenCoin[i] = coin;
+                }
+            }
+        }
+
+        if (dp[target] == int.MaxValue) throw new ArgumentException("Cannot find a solution");
+
+        List<int> result = new List<int>();
+        while (target > 0)
+        {
+            result.Add(chosenCoin[target]);
+            target -= chosenCoin[target];
+        }
+
+        return result.ToArray();
+    }
+}

--- a/change/Change.csproj
+++ b/change/Change.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/change/ChangeTests.cs
+++ b/change/ChangeTests.cs
@@ -1,0 +1,109 @@
+using System;
+using Xunit;
+
+public class ChangeTests
+{
+    [Fact]
+    public void Change_for_1_cent()
+    {
+        var coins = new[] { 1, 5, 10, 25 };
+        var target = 1;
+        var expected = new[] { 1 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Single_coin_change()
+    {
+        var coins = new[] { 1, 5, 10, 25, 100 };
+        var target = 25;
+        var expected = new[] { 25 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Multiple_coin_change()
+    {
+        var coins = new[] { 1, 5, 10, 25, 100 };
+        var target = 15;
+        var expected = new[] { 5, 10 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Change_with_lilliputian_coins()
+    {
+        var coins = new[] { 1, 4, 15, 20, 50 };
+        var target = 23;
+        var expected = new[] { 4, 4, 15 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Change_with_lower_elbonia_coins()
+    {
+        var coins = new[] { 1, 5, 10, 21, 25 };
+        var target = 63;
+        var expected = new[] { 21, 21, 21 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Large_target_values()
+    {
+        var coins = new[] { 1, 2, 5, 10, 20, 50, 100 };
+        var target = 999;
+        var expected = new[] { 2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Possible_change_without_unit_coins_available()
+    {
+        var coins = new[] { 2, 5, 10, 20, 50 };
+        var target = 21;
+        var expected = new[] { 2, 2, 2, 5, 10 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Another_possible_change_without_unit_coins_available()
+    {
+        var coins = new[] { 4, 5 };
+        var target = 27;
+        var expected = new[] { 4, 4, 4, 5, 5, 5 };
+        Assert.Equal(expected, Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void No_coins_make_0_change()
+    {
+        var coins = new[] { 1, 5, 10, 21, 25 };
+        var target = 0;
+        Assert.Empty(Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Error_testing_for_change_smaller_than_the_smallest_of_coins()
+    {
+        var coins = new[] { 5, 10 };
+        var target = 3;
+        Assert.Throws<ArgumentException>(() => Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Error_if_no_combination_can_add_up_to_target()
+    {
+        var coins = new[] { 5, 10 };
+        var target = 94;
+        Assert.Throws<ArgumentException>(() => Change.FindFewestCoins(coins, target));
+    }
+
+    [Fact]
+    public void Cannot_find_negative_change_values()
+    {
+        var coins = new[] { 1, 2, 5 };
+        var target = -5;
+        Assert.Throws<ArgumentException>(() => Change.FindFewestCoins(coins, target));
+    }
+}

--- a/change/README.md
+++ b/change/README.md
@@ -1,0 +1,38 @@
+# Change
+
+Welcome to Change on Exercism's C# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Correctly determine the fewest number of coins to be given to a customer such that the sum of the coins' value would equal the correct amount of change.
+
+## For example
+
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) or [5, 10]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) and one quarter (25) or [5, 10, 25]
+
+## Edge cases
+
+- Does your algorithm work for any given set of coins?
+- Can you ask for negative change?
+- Can you ask for a change value smaller than the smallest coin value?
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @FizzBuzz791
+- @j2jensen
+- @robkeim
+- @sjwarner-bp
+- @wolf99
+- @Zureka
+
+### Based on
+
+Software Craftsmanship - Coin Change Kata - https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata


### PR DESCRIPTION
This commit introduces the 'Change' project to the existing solution. The new functionality allows the calculation of the fewest number of coins needed for a target change from a provided set of coins. This solution takes into account edge cases, like negative target or a target smaller than the smallest coin. An extensive set of tests is also added to ensure correctness under various scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated CodeRabbit for enhanced coding assistance features such as early access, review automation, and chat auto-reply.
	- Added a new "Change" project to the solution, featuring a method to calculate the fewest number of coins needed for a given target value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->