### PR TITLE
Add 'Grains' project and associated tests

### DIFF
--- a/Exercism.sln
+++ b/Exercism.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalculatorConundrum", "calc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Change", "change\Change.csproj", "{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grains", "grains\Grains.csproj", "{B9C521B8-DEB1-41F1-8022-44DB6A889B41}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E47BF8DC-3549-4F64-B3F5-60F61B5D7D7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9C521B8-DEB1-41F1-8022-44DB6A889B41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9C521B8-DEB1-41F1-8022-44DB6A889B41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9C521B8-DEB1-41F1-8022-44DB6A889B41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9C521B8-DEB1-41F1-8022-44DB6A889B41}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/grains/Grains.cs
+++ b/grains/Grains.cs
@@ -1,0 +1,14 @@
+using System;
+
+public static class Grains
+{
+    private const int MinSquareNumber = 1;
+    private const int MaxSquareNumber = 64;
+
+    public static ulong Square(int n) => n is < MinSquareNumber or > MaxSquareNumber
+        ? throw new ArgumentOutOfRangeException(nameof(n),
+            $"Input must be within the range of {MinSquareNumber} and {MaxSquareNumber} inclusive.")
+        : 1ul << --n;
+
+    public static ulong Total() => ~0ul;
+}

--- a/grains/Grains.csproj
+++ b/grains/Grains.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/grains/GrainsTests.cs
+++ b/grains/GrainsTests.cs
@@ -1,0 +1,71 @@
+using System;
+using Xunit;
+
+public class GrainsTests
+{
+    [Fact]
+    public void Grains_on_square_1()
+    {
+        Assert.Equal(1UL, Grains.Square(1));
+    }
+
+    [Fact]
+    public void Grains_on_square_2()
+    {
+        Assert.Equal(2UL, Grains.Square(2));
+    }
+
+    [Fact]
+    public void Grains_on_square_3()
+    {
+        Assert.Equal(4UL, Grains.Square(3));
+    }
+
+    [Fact]
+    public void Grains_on_square_4()
+    {
+        Assert.Equal(8UL, Grains.Square(4));
+    }
+
+    [Fact]
+    public void Grains_on_square_16()
+    {
+        Assert.Equal(32768UL, Grains.Square(16));
+    }
+
+    [Fact]
+    public void Grains_on_square_32()
+    {
+        Assert.Equal(2147483648UL, Grains.Square(32));
+    }
+
+    [Fact]
+    public void Grains_on_square_64()
+    {
+        Assert.Equal(9223372036854775808UL, Grains.Square(64));
+    }
+
+    [Fact]
+    public void Square_0_raises_an_exception()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(0));
+    }
+
+    [Fact]
+    public void Negative_square_raises_an_exception()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(-1));
+    }
+
+    [Fact]
+    public void Square_greater_than_64_raises_an_exception()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Grains.Square(65));
+    }
+
+    [Fact]
+    public void Returns_the_total_number_of_grains_on_the_board()
+    {
+        Assert.Equal(18446744073709551615UL, Grains.Total());
+    }
+}

--- a/grains/README.md
+++ b/grains/README.md
@@ -1,0 +1,38 @@
+# Grains
+
+Welcome to Grains on Exercism's C# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.
+
+There once was a wise servant who saved the life of a prince.
+The king promised to pay whatever the servant could dream up.
+Knowing that the king loved chess, the servant told the king he would like to have grains of wheat.
+One grain on the first square of a chess board, with the number of grains doubling on each successive square.
+
+There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
+
+Write code that shows:
+
+- how many grains were on a given square, and
+- the total number of grains on the chessboard
+
+## Source
+
+### Created by
+
+- @robkeim
+
+### Contributed to by
+
+- @ErikSchierboom
+- @FizzBuzz791
+- @j2jensen
+- @tushartyagi
+- @wolf99
+
+### Based on
+
+The CodeRanch Cattle Drive, Assignment 6 - https://coderanch.com/wiki/718824/Grains


### PR DESCRIPTION
This commit introduces a new 'Grains' project to the solution which involves calculation of grains on a chessboard where the number on each square doubles. Moreover, tests have been added to ensure the functionality works as expected, including handling out of range exceptions. The solution file has been updated to include this new project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Grains" project for calculating the number of grains on a chessboard, including error handling for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->